### PR TITLE
Lag release-draft etter build på main

### DIFF
--- a/.github/workflows/build-deploy-main.yml
+++ b/.github/workflows/build-deploy-main.yml
@@ -15,6 +15,6 @@ jobs:
       build-tag: ${{ needs.build-main.outputs.build-tag }}
   draft-release:
     uses: navikt/dok-workflows/.github/workflows/release-draft.yml@main
-    needs: [build-main, deploy-main]
+    needs: build-main
     with:
       build-tag: ${{ needs.build-main.outputs.build-tag }}


### PR DESCRIPTION
Ref. issue https://github.com/navikt/dok-workflows/issues/4 endrar vi slik at release-draft blir oppretta etter build-steget er fullført. Då slepp ein å vente på dev-deploy for å få gjort prod-deploy.