### PR TITLE
MMA-7346: Add shibboleth for å få tak i manglende dependencies i dokprod

### DIFF
--- a/.github/workflows/build-app-gar.yml
+++ b/.github/workflows/build-app-gar.yml
@@ -61,6 +61,7 @@ jobs:
             { "id": "github", "url": "https://maven.pkg.github.com/navikt/maven-release", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } },
             { "id": "confluent", "url": "https://packages.confluent.io/maven/" },
             { "id": "jitpack", "url": "https://jitpack.io" }
+            { "id": "shibboleth", "url": "https://build.shibboleth.net/nexus/content/repositories/releases/" }
           ]'
           servers: '[
             { "id": "github", "username": "x-access-token", "password": "${{ secrets.READER_TOKEN }}" }


### PR DESCRIPTION
Shibboleth-repoet trengs for noen opensaml-dependencies i dokprod. Repoet ligger allerede i det gamle build-artifact, men det ser ikke ut til at det har blitt tatt med til build-app-gar. Drar det derfor inn nå