### PR TITLE
Legg til checks: read tilgang for automerge workflow

### DIFF
--- a/.github/workflows/automerge-dependabot-pr.yml
+++ b/.github/workflows/automerge-dependabot-pr.yml
@@ -48,6 +48,7 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: write
       pull-requests: write
       statuses: read

--- a/eksempel/.github/workflows/automerge-dependabot-pr.yml
+++ b/eksempel/.github/workflows/automerge-dependabot-pr.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   automerge:
     permissions:
+      checks: read
       contents: write
       pull-requests: write
       statuses: read


### PR DESCRIPTION
Ref [denne](https://github.com/navikt/automerge-dependabot/commit/4999da96d2209419f186f524af6f961ca279cf31) endringen leser jeg det sik at automerge nå trenger check: read permission. Mistenker alle workflows som bruker automerge også trenger denne.