### PR TITLE
MMA-8778 Erstatt whelk-io/maven-settings-xml-action

### DIFF
--- a/.github/workflows/build-app-gar.yml
+++ b/.github/workflows/build-app-gar.yml
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-maven-${{ steps.m2-cache-key.outputs.yearweek }}-
       # maven build
       - name: Create m2-settings
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 #v4.0.0
         with:
           repositories: '[
             { "id": "central", "url": "https://repo1.maven.org/maven2/", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } },
@@ -79,7 +79,6 @@ jobs:
           servers: '[
             { "id": "github", "username": "x-access-token", "password": "${{ secrets.READER_TOKEN }}" }
           ]'
-          output_file: settings.xml
       - name: Download toolchain file
         run: |
           curl https://raw.githubusercontent.com/navikt/dok-workflows/main/resources/toolchains.xml --output toolchains.xml

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Create m2-settings
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 #v4.0.0
         with:
           repositories: '[
             { "id": "central", "url": "https://repo1.maven.org/maven2/", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } },
@@ -36,7 +36,6 @@ jobs:
           servers: '[
             { "id": "github", "username": "x-access-token", "password": "${{ secrets.READER_TOKEN }}" }
           ]'
-          output_file: settings.xml
       - name: Set up JDK${{ inputs.java-version || needs.determine-java-version.outputs.java-version }} and cache dependencies
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Create m2-settings
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 #v4.0.0
         with:
           repositories: '[
             { "id": "github", "url": "https://maven.pkg.github.com/navikt/maven-release", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } },
@@ -27,7 +27,6 @@ jobs:
             { "id": "github", "username": "x-access-token", "password": "${{ secrets.READER_TOKEN }}" },
             { "id": "ghcr", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" }
           ]'
-          output_file: settings.xml
       - name: Set up JDK${{ inputs.java-version }} and cache dependencies
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
whelk-io/maven-settings-xml-action har blitt arkivert. Det ser ut til at s4u/maven-settings-action kan erstatte det, og det er andre team i Nav som bruker dette.

Ser ut som at den vi brukte, og den det er erstatta med er dei mest relevante alternativa: https://github.com/marketplace?query=settings.xml&type=actions